### PR TITLE
docs: add GitHub PR and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug Report
+about: Reporte de erros ou problemas no projeto
+title: "[BUG] "
+labels: bug
+assignees: 
+---
+
+## 📌 Descrição do problema
+<!-- Explique claramente qual é o problema encontrado -->
+
+## 🖥️ Ambiente
+- Sistema operacional:
+- Versão do Python / Node / etc:
+- Versão do projeto (se aplicável):
+
+## 🔄 Passos para reproduzir
+1. 
+2. 
+3. 
+
+## ✅ Comportamento esperado
+<!-- O que você esperava que acontecesse? -->
+
+## ❌ Comportamento observado
+<!-- O que aconteceu de fato? -->
+
+## 📝 Notas adicionais
+<!-- Qualquer informação extra que ajude na análise do bug -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature Request / Documentation
+about: Sugestão de nova funcionalidade ou melhoria na documentação
+title: "[FEATURE] "
+labels: enhancement
+assignees: 
+---
+
+## 📌 Descrição da sugestão
+<!-- Explique de forma clara o que você está sugerindo -->
+
+## 🎯 Motivação
+<!-- Qual problema esta feature resolve ou qual melhoria traz? -->
+
+## 🔄 Comportamento esperado
+<!-- Como você espera que a funcionalidade se comporte? -->
+
+## 📝 Notas adicionais
+<!-- Qualquer detalhe extra que possa ajudar na implementação ou revisão -->

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request-template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request-template.md
@@ -1,0 +1,24 @@
+## 📌 Descrição
+<!-- Explique de forma clara e resumida o que este PR faz -->
+
+## 🔄 Tipo de mudança
+Marque com um `x` o que se aplica:
+- [ ] fix (correção de bug)
+- [ ] feat (nova funcionalidade)
+- [ ] docs (mudança na documentação)
+- [ ] refactor (mudança no código sem alterar funcionalidade)
+- [ ] chore (tarefas diversas, configs, build, etc.)
+- [ ] test (adição ou correção de testes)
+
+## ✅ Mudanças realizadas
+<!-- Liste as mudanças principais deste PR -->
+- 
+
+## 🎯 Motivação
+<!-- Qual problema este PR resolve ou que melhoria traz? -->
+
+## 📊 Impacto
+<!-- Existe algum impacto no código, na infra ou nos usuários? -->
+
+## 📝 Notas adicionais
+<!-- Algum detalhe extra que revisores devem saber? -->


### PR DESCRIPTION
Adicionam-se templates para pull requests e issues:

 - Template de PR para padronizar a descrição dos Pull Requests
 - Template de Issue para reporte de bugs
 - Template de Issue para requests de funcionalidades ou melhorias na documentação