### PR TITLE
fix: use attribute access for Pydantic model in register_company

### DIFF
--- a/services.py
+++ b/services.py
@@ -107,13 +107,13 @@ class Service:
             raise HTTPException(status_code=400, detail=f'Invalid public key: {str(e)}')
 
     def register_company(self, data):
-        self.validate_public_key(data['company_public_key'])
+        self.validate_public_key(data.company_public_key)
         company_id = str(uuid.uuid4())
         self.nosql.store_company_in_db(
             company_id=company_id,
-            public_key=data['company_public_key'],
-            company_name=data['company_name'],
-            alert_emails=data['alert_emails']
+            public_key=data.company_public_key,
+            company_name=data.company_name,
+            alert_emails=data.alert_emails
         )
         return company_id
 


### PR DESCRIPTION
## 📌 Descrição
Corrige o acesso aos atributos do modelo Pydantic em register_company, evitando o erro 'object is not subscriptable'.

## 🔄 Tipo de mudança
Marque com um `x` o que se aplica:
- [x] fix (correção de bug)
- [ ] feat (nova funcionalidade)
- [ ] docs (mudança na documentação)
- [ ] refactor (mudança no código sem alterar funcionalidade)
- [ ] chore (tarefas diversas, configs, build, etc.)
- [ ] test (adição ou correção de testes)

## ✅ Mudanças realizadas
- Alterado o acesso a `data['company_public_key']`, `data['company_name']` e `data['alert_emails']` para `data.company_public_key`, `data.company_name` e `data.alert_emails`.

## 🎯 Motivação
Evitar o erro `'CompanyRegisterSchema' object is not subscriptable` ao registrar uma empresa usando Pydantic.

## 📊 Impacto
Corrige apenas a forma de acesso aos atributos do modelo, sem impacto em outras partes do sistema.

## 📝 Notas adicionais
Revisar outros métodos que possam acessar modelos Pydantic usando indexação e ajustá-los se necessário.