### PR TITLE
fix: Expor autenticação JWT na documentação do Swagger

### DIFF
--- a/routers/router.py
+++ b/routers/router.py
@@ -5,10 +5,12 @@ from typing import Optional, List
 from datetime import datetime
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import JSONResponse
+from fastapi.security import HTTPBearer
 
 
 router = APIRouter()
 service = Service()
+security = HTTPBearer()
 
 
 class RegisterRequestSchema(BaseModel):
@@ -72,7 +74,7 @@ def request_registration(data: RegisterRequestSchema):
     return {'message': 'A temporary registration email has been sent to your email.'}
 
 @router.post("/register_company")
-def register_company(data: CompanyRegisterSchema): 
+def register_company(data: CompanyRegisterSchema):
     try:
         service.verify_registration_token(data.token)
         company_id = service.register_company(data)
@@ -82,7 +84,7 @@ def register_company(data: CompanyRegisterSchema):
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
-@router.post("/logs")
+@router.post("/logs", dependencies=[Depends(security)])
 def receive_logs(log: LogSchema, payload=Depends(service.verify_logs_token)):
     try:
         company_name = payload['iss']


### PR DESCRIPTION
## 📌 Descrição
Corrige o problema de autenticação JWT na documentação do Swagger, permitindo que o token seja enviado corretamente para os endpoints que exigem autenticação.

## 🔄 Tipo de mudança
Marque com um `x` o que se aplica:
- [x] fix (correção de bug)
- [ ] feat (nova funcionalidade)
- [ ] docs (mudança na documentação)
- [ ] refactor (mudança no código sem alterar funcionalidade)
- [ ] chore (tarefas diversas, configs, build, etc.)
- [ ] test (adição ou correção de testes)

## ✅ Mudanças realizadas
- Exposição do esquema de segurança `HTTPBearer` nos endpoints.
- Correção para que o Swagger Docs mostre o botão **Authorize**.
- Ajustes na função `verify_logs_token` para aceitar corretamente o token.

## 🎯 Motivação
Sem essa correção, a documentação do Swagger não permitia enviar o token JWT, gerando erros de autenticação 403 ("Not authenticated").

## 📊 Impacto
- Usuários agora podem testar endpoints autenticados diretamente pelo Swagger.
- Nenhum impacto negativo no código ou na infraestrutura existente.

## 📝 Notas adicionais
- Continua sendo necessário um token JWT válido para testar os endpoints.
- A correção é compatível com os endpoints existentes.