### PR TITLE
fix: corrige envio de email convertendo dict em JSON antes de anexar

### DIFF
--- a/db_nosql.py
+++ b/db_nosql.py
@@ -76,10 +76,7 @@ class Nosql:
     def search_log_in_db(self, filters):
         try:
             collection = self.db[config('COLLECTION_LOGS')]
-            print(collection)
             result = list(collection.find(filters))
-            for doc in collection.find({}, {"log.timestamp": 1}).limit(5):
-                print(doc)
             return result
         except Exception:
             raise

--- a/services.py
+++ b/services.py
@@ -157,7 +157,6 @@ class Service:
             end_dt = data['end_date'] if isinstance(data['end_date'], datetime) else datetime.fromisoformat(
                 data['end_date'].replace("Z", "+00:00"))
 
-
             query['received_at'] = {
                 '$gte': start_dt,
                 '$lte': end_dt

--- a/services.py
+++ b/services.py
@@ -1,3 +1,5 @@
+import json
+
 import jwt
 import smtplib
 import uuid
@@ -39,7 +41,7 @@ class Service:
         msg['To'] = addressee
         msg['Subject'] = subject
 
-        msg.attach(MIMEText(content_text, 'plain'))
+        msg.attach(MIMEText(json.dumps(content_text, indent=2), 'plain'))
 
         with smtplib.SMTP('sandbox.smtp.mailtrap.io', 587) as server:
             server.starttls()
@@ -160,10 +162,6 @@ class Service:
                 '$gte': start_dt,
                 '$lte': end_dt
             }
-
-        # if not query:
-        #     raise ValueError('No filters provided for log search')
-        print(query)
 
         result = self.nosql.search_log_in_db(query)
         flattened = []


### PR DESCRIPTION
## 📌 Descrição
Este PR corrige o envio de emails, convertendo objetos `dict` para string JSON antes de anexar, evitando o erro `'dict' object has no attribute 'encode'`.

## 🔄 Tipo de mudança
Marque com um `x` o que se aplica:
- [x] fix (correção de bug)
- [ ] feat (nova funcionalidade)
- [ ] docs (mudança na documentação)
- [ ] refactor (mudança no código sem alterar funcionalidade)
- [ ] chore (tarefas diversas, configs, build, etc.)
- [ ] test (adição ou correção de testes)

## ✅ Mudanças realizadas
- Converte `dict` para JSON antes de anexar no email usando `MIMEText`.
- 

## 🎯 Motivação
Resolver o erro que ocorria ao anexar diretamente um `dict` em emails, garantindo que o envio funcione corretamente.

## 📊 Impacto
Nenhum impacto em outras partes do sistema, apenas corrige o envio de emails com anexos do tipo `dict`.

## 📝 Notas adicionais
O conteúdo do email agora sempre é convertido para string JSON antes de ser anexado. Não altera o restante do fluxo de envio.